### PR TITLE
Fix thread leak: Don't create ~270 threads

### DIFF
--- a/AXEmojiView/AXEmojiView/src/main/java/com/aghajari/emojiview/emoji/iosprovider/AXIOSEmoji.java
+++ b/AXEmojiView/AXEmojiView/src/main/java/com/aghajari/emojiview/emoji/iosprovider/AXIOSEmoji.java
@@ -37,8 +37,7 @@ public class AXIOSEmoji extends Emoji {
 
         boolean isVariants = EmojiData.isColoredEmoji(code);
         if (isVariants) {
-            DispatchQueue run = new DispatchQueue("emoji");
-            run.postRunnable(new Runnable() {
+            AXIOSEmojiLoader.globalQueue.postRunnable(new Runnable() {
                 @Override
                 public void run() {
                     AXIOSEmoji[] variants = new AXIOSEmoji[5];


### PR DESCRIPTION
This is especially important for android 5.x devices, as they have a stricter FileDescriptor limit, and each Thread (that won't be stopped in the current DispatchQueue implementation) creates several FileDescriptors.

By reusing the already existing globalQueue, only 1 Thread (the globalQueue) will be created. This is better than 270 Threads being created (measured via `Thread.activeCount()`)